### PR TITLE
Bg user story 9

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -22,6 +22,8 @@ class CartController < ApplicationController
     redirect_to '/cart'
   end
 
+  private
+
   def deny_admin
     render file: "/public/404" if current_admin?
   end

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,4 +1,6 @@
 class CartController < ApplicationController
+  before_action :deny_admin
+
   def add_item
     item = Item.find(params[:item_id])
     cart.add_item(item.id.to_s)
@@ -18,6 +20,10 @@ class CartController < ApplicationController
   def remove_item
     session[:cart].delete(params[:item_id])
     redirect_to '/cart'
+  end
+
+  def deny_admin
+    render file: "/public/404" if current_admin?
   end
 
   # def increment_decrement

--- a/spec/features/admin/nav_spec.rb
+++ b/spec/features/admin/nav_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'rails_helper'
 
-RSpec.describe 'As a Admin I have a navbar', type: :feature do
-  describe 'where I can click on' do
-    before(:all) do
-      @user1 = User.new(
+RSpec.describe 'As a Admin', type: :feature do
+  describe 'I have a navbar' do
+    it 'where I can click on' do
+      user1 = User.new(
         email_address: "user1@example.com",
         role: 3,
         password: "password",
@@ -16,71 +16,80 @@ RSpec.describe 'As a Admin I have a navbar', type: :feature do
           zip_code: "12345"
         )
       )
-      @user1.save
-    end
+      user1.save
+      
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
 
-    before(:each) do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
-    end
+      visit root_path
 
-    it 'home' do
-      visit '/register'
-      click_on 'Home'
-      expect(current_path).to eq(root_path)
-    end
-    it 'All Merchants' do
-      visit '/'
       click_on 'All Merchants'
       expect(current_path).to eq(merchants_path)
-    end
 
-    it 'All Items' do
-      visit '/'
+      click_on 'Home'
+      expect(current_path).to eq(root_path)
+
       click_on 'All Items'
       expect(current_path).to eq(items_path)
-    end
 
-    it 'Cart' do
-      visit '/'
-      expect(page).to_not have_link('Cart')
-    end
-
-    it 'Login' do
-      visit '/'
-      expect(page).to_not have_link('Login')
-    end
-
-    it 'Register' do
-      visit '/'
-      expect(page).to_not have_link('Register')
-    end
-
-    it 'Dashboard' do
-      visit '/'
       click_on 'Dashboard'
       expect(current_path).to eq(admin_dashboard_path)
-    end
-
-    it 'Users' do
-      visit '/'
+      
       click_on 'Users'
       expect(current_path).to eq(admin_users_path)
-    end
-
-    it 'Profile' do
-      visit '/'
+      
       click_on 'Profile'
       expect(current_path).to eq(profile_path)
-    end
-
-    it 'Logout' do
-      visit '/'
+      
       click_on 'Logout'
       expect(current_path).to eq(root_path)
+      
+      expect(page).to_not have_link('Cart')
+
+      expect(page).to_not have_link('Login')
+
+      expect(page).to_not have_link('Register')
     end
-    after(:all) do
-      UserDetail.destroy_all
-      User.destroy_all
+  end
+
+  describe 'I do not have access' do
+    it '/merchant routes' do
+      user1 = User.new(
+        email_address: "user1@example.com",
+        role: 3,
+        password: "password",
+        user_detail: UserDetail.new(        
+          name: "User 1",
+          street_address: "123 Example St",
+          city: "Userville",
+          state: "State 1",
+          zip_code: "12345"
+        )
+      )
+      user1.save
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+      visit merchant_dashboard_path
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+    end
+  
+    it '/cart routes' do
+      user1 = User.new(
+        email_address: "user1@example.com",
+        role: 3,
+        password: "password",
+        user_detail: UserDetail.new(        
+          name: "User 1",
+          street_address: "123 Example St",
+          city: "Userville",
+          state: "State 1",
+          zip_code: "12345"
+        )
+      )
+      user1.save
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+      visit cart_path
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
     end
   end
   


### PR DESCRIPTION
## Authorized routes for Admin
Closes: #12 
### Created
- deny_admin method in cart controller.
   - renders 404 if admin user attempts any cart action 
- added deny_admin to before actions.