### PR TITLE
Bg order status

### DIFF
--- a/app/controllers/merchant/item_orders_controller.rb
+++ b/app/controllers/merchant/item_orders_controller.rb
@@ -5,7 +5,7 @@ class Merchant::ItemOrdersController < Merchant::BaseController
     if item_order.fulfill
       flash[:success] = "#{item_order.item.name} has been fulfilled"
     else
-        flash[:error] = item_order.errors.full_messages.to_sentence
+      flash[:error] = item_order.errors.full_messages.to_sentence
     end
     redirect_to merchant_order_show_path(item_order.order)
   end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -12,7 +12,8 @@ class ItemOrder <ApplicationRecord
     if fillable?
       item.update(inventory: item.inventory - quantity)
       update(status: "fulfilled")
-      order.update(status: "packaged") if items.where(status: "unfulfilled").any?
+      order.set_order_packaged
+      true
     end
   end
   
@@ -32,7 +33,9 @@ class ItemOrder <ApplicationRecord
   end
 
   def items
-    ItemOrder.where('order_id = ?', order.id)
+    binding.pry
+    order.order_items
+    # ItemOrder.where('order_id = ?', order.id)
   end
 
   def belongs_to_merchant_id?(merchant_id)

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -32,12 +32,6 @@ class ItemOrder <ApplicationRecord
     false
   end
 
-  def items
-    binding.pry
-    order.order_items
-    # ItemOrder.where('order_id = ?', order.id)
-  end
-
   def belongs_to_merchant_id?(merchant_id)
     item.merchant.id == merchant_id
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -21,6 +21,14 @@ class Order <ApplicationRecord
     self.update(status: "canceled")
   end
 
+  def set_order_packaged
+    return false if canceled?
+    update(status: "packaged") unless item_orders.where(status: "unfulfilled").any?
+  end
+
+  def canceled?
+    status == "canceled"
+  end
 
   def number_of_items_for_merchant(merchant_id)
     item_orders.joins(:item).where(items: {merchant_id: merchant_id}).sum(:quantity)

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -18,8 +18,10 @@ describe ItemOrder, type: :model do
       @user = User.create!(email_address: 'user1@example.com', password: 'password', role: 'default', name: 'User 1', street_address: '123 Example St', city: 'Userville', state: 'State 1', zip_code: '12345')
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @tire_2 = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @order_1 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       @item_order_1 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+      @item_order_2 = @order_1.item_orders.create!(item: @tire_2, price: @tire_2.price, quantity: 3)
       
     end
     it 'subtotal' do
@@ -27,10 +29,18 @@ describe ItemOrder, type: :model do
     end
 
     it 'fulfill' do
+      expect(@order_1.status).to eq("pending")
+
       @item_order_1.fulfill
-      
+      @order_1.reload
+      expect(@order_1.status).to eq("pending")
       expect(@item_order_1.status).to eq("fulfilled")
       expect(@tire.inventory).to eq(10)
+
+      @item_order_2.fulfill
+      @order_1.reload
+
+      expect(@order_1.status).to eq("packaged")
     end
 
     it 'fulfilled?' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -80,6 +80,22 @@ describe Order, type: :model do
       expect(@order_1.status).to eq("shipped")
     end
 
+    it 'set_order_packaged' do
+      expect(@order_1.status).to eq("pending")
+      @item_order_pull_toy.fulfill
+
+      expect(@order_1.status).to eq("pending")
+      @item_order_tire.fulfill
+      
+      expect(@order_1.status).to eq("packaged")
+    end
+
+    it 'canceled?' do
+      @order_1.update(status: "canceled")
+
+      expect(@order_1.canceled?).to eq(true)
+    end
+
     after(:each) do
       ItemOrder.destroy_all
       Order.destroy_all


### PR DESCRIPTION
## Order status now updates correctly
Closes #127 
- Expanded item order fulfill test to include failing state
- item order fulfill method now returns true if successful
- Added helper methods to Order, set_order_packaged and canceled?