### PR TITLE
Kelsha Darby - Fixes - User Stories 47 & 48

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,7 @@ class ItemsController<ApplicationController
     @item = Item.find(params[:id])
     @item.update(item_params)
     if @item.save
+      flash[:success] = "#{@item.name} has been updated successfully"
       dynamic_redirect
     else
       flash.now[:error] = @item.errors.full_messages.to_sentence

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,7 +9,7 @@
     <%= text_field_tag :description, "#{@item.description}" %>
 
     <%= label_tag :price %>
-    <%= text_field_tag :price, "#{number_to_currency(@item.price)}" %>
+    <%= text_field_tag :price, "#{@item.price}" %>
 
     <%= label_tag :image %>
     <%= text_field_tag :image, "#{@item.image}" %>

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe "As a Visitor" do
         expect(page).to have_content("Name can't be blank and Description can't be blank")
         expect(page).to have_button("Update Item")
       end
+
+      it 'I get a flash message if I put a float into price or inventory' do
+        @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+        @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+        visit "/items/#{@tire.id}"
+
+        click_on "Edit Item"
+
+        fill_in 'Name', with: "Gatorskins"
+        fill_in 'Price', with: 0.7
+        fill_in 'Description', with: "They'll never pop!"
+        fill_in 'Image', with: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588"
+        fill_in 'Inventory', with: 0.5
+
+        click_button "Update Item"
+
+        expect(page).to have_content("Price must be an integer and Inventory must be an integer")
+        expect(page).to have_button("Update Item")
+      end
+
     end
   end
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "As a Visitor" do
         expect(current_path).to eq("/items/#{@tire.id}/edit")
         expect(page).to have_link("Gatorskins")
         expect(find_field('Name').value).to eq "Gatorskins"
-        expect(find_field('Price').value).to eq '$100.00'
+        expect(find_field('Price').value).to_not eq '$100.00'
+        expect(find_field('Price').value).to eq '100'
         expect(find_field('Description').value).to eq "They'll never pop!"
         expect(find_field('Image').value).to eq("https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588")
         expect(find_field('Inventory').value).to eq '12'

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "As a Visitor" do
 
         click_button "Update Item"
 
+        expect(page).to have_content("GatorSkins has been updated successfully")
         expect(current_path).to eq("/items/#{@tire.id}")
         expect(page).to have_content("GatorSkins")
         expect(page).to_not have_content("Gatorskins")


### PR DESCRIPTION
## Merchant User Item Update
Closes #132 

**_Test_**
- Add it block to test that the edit form cannot accept floats
- Add to existing test to ensure that the price is not changed to "$0.00" when a user incorrectly fills out a form
- Add to existing test to ensure that flash message appears when item is updated

**_View_**
- Remove `number_to_currency` from price in the edit form to ensure that it is reverted back to an integer when a user incorrectly submits a form

**_Controller_**
- Add successful item update flash message to update method of items controller (not nested)